### PR TITLE
docs: add Android ProGuard/R8 setup instructions (fixes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,34 @@ For the package to work correctly on iOS, you need to configure your iOS project
 </details>
 
 
+## ⛔️ Android Setup
+
+### Required Android Configuration
+
+For the package to work correctly on Android, you need to configure your Android project ([reference](https://onnxruntime.ai/docs/build/android.html#note-proguard-rules-for-r8-minimization-android-app-builds-to-work)):
+
+1. **Update your build config** (`android/app/build.gradle.kts`):
+   ```kotlin
+   isMinifyEnabled = true
+   isShrinkResources = true
+   proguardFiles(
+       getDefaultProguardFile("proguard-android-optimize.txt"),
+       "proguard-rules.pro"
+   )
+   ```
+
+2. **Update/add your ProGuard rules** (`android/app/proguard-rules.pro`):
+   ```
+   -keep class ai.onnxruntime.** { *; }
+   ```
+
+## 📋 More Troubleshooting
+
+`image_background_remover` is built on top of [`flutter_onnxruntime`](https://pub.dev/packages/flutter_onnxruntime), which maintains its own troubleshooting guide covering platform-specific issues. You can read it [here](https://github.com/masicai/flutter_onnxruntime/blob/main/doc/troubleshooting.md).
+
+If you run into an error, it's worth checking that guide as well.
+
+
 ## ⚠️ Warning
 
 This package uses an offline model to process images, which is bundled with the application. **This may increase the size of your app**. 


### PR DESCRIPTION
## What
Adds an "Android Setup" section to the README with the ProGuard/R8 configuration needed to avoid a JNI crash (`java_class == null`) that happens on Android release builds.

Also adds a short "More Troubleshooting" section pointing to flutter_onnxruntime's own troubleshooting guide, since this package is built on top of it and users may run into other platform-specific issues (Kotlin version mismatches, CocoaPods conflicts, etc.) that are out of scope for this PR but documented there.

## Why
Reported in #20 by @Daftus. I ran into the same crash independently and found the fix documented in ONNX Runtime's own Android build docs: https://onnxruntime.ai/docs/build/android.html#note-proguard-rules-for-r8-minimization-android-app-builds-to-work

The same fix is also confirmed in flutter_onnxruntime's troubleshooting guide, citing the same source.

## Changes
- Added an "Android Setup" section documenting the required `isMinifyEnabled` / ProGuard config.
- Added a "More Troubleshooting" section linking to flutter_onnxruntime's troubleshooting guide for other platform issues.

No code changes - documentation only.

Related to #20